### PR TITLE
Increase customization of Powerplay window

### DIFF
--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -112,6 +112,23 @@ function testKillfeed(team) {
   })
 }
 
+function testPPTimer(shouldShow) {
+  LPTE.emit({
+    meta: {
+      namespace: 'module-league-in-game',
+      type: 'pp-update',
+      version: 1
+    },
+    type: document.getElementById('pp-test').options[
+      document.getElementById('pp-test').selectedIndex
+    ].text,
+    ongoing: shouldShow,
+    percent: 10,
+    respawnIn: 300,
+    respawnAt: 0
+  })
+}
+
 function initSettings(settings) {
   const itemOptions = document.querySelector('#items').options
   for (let i = 0; i < itemOptions.length; i++) {

--- a/frontend/gfx/ingame.css
+++ b/frontend/gfx/ingame.css
@@ -587,6 +587,12 @@ body {
   margin: 0 100px;
 }
 
+.pp-text {
+  font-family: var(--primary-font-family);
+  font-size: 35px;
+  color: var(--text-color);
+}
+
 .plates,
 .gold {
   display: flex;

--- a/frontend/gfx/ingame.html
+++ b/frontend/gfx/ingame.html
@@ -11,16 +11,16 @@
   </head>
   <body class="module-league-in-game">
     <div id="elder" class="power-play hide">
-      <img src="img/elder.png" alt="elder" />
-      <h1>Elder</h1>
+      <img class="baron-pp" src="img/elder.png" alt="elder" />
+      <h1 class="pp-text">Elder</h1>
       <div class="pp-bar"></div>
-      <!-- <h2 class="timer">3:00</h2> -->
+      <h2 class="timer">3:00</h2>
     </div>
     <div id="baron" class="power-play hide">
-      <img src="img/baron.png" alt="elder" />
-      <h1>Baron</h1>
+      <img class="baron-pp" src="img/baron.png" alt="baron" />
+      <h1 class="pp-text">Baron</h1>
       <div class="pp-bar"></div>
-      <!-- <h2 class="timer">3:00</h2> -->
+      <h2 class="timer">3:00</h2>
     </div>
 
     <div id="platings" class="hide">

--- a/frontend/gfx/ingame.html
+++ b/frontend/gfx/ingame.html
@@ -11,7 +11,7 @@
   </head>
   <body class="module-league-in-game">
     <div id="elder" class="power-play hide">
-      <img class="baron-pp" src="img/elder.png" alt="elder" />
+      <img class="elder-pp" src="img/elder.png" alt="elder" />
       <h1 class="pp-text">Elder</h1>
       <div class="pp-bar"></div>
       <!-- <h2 class="timer">3:00</h2> -->

--- a/frontend/gfx/ingame.html
+++ b/frontend/gfx/ingame.html
@@ -14,13 +14,13 @@
       <img class="baron-pp" src="img/elder.png" alt="elder" />
       <h1 class="pp-text">Elder</h1>
       <div class="pp-bar"></div>
-      <h2 class="timer">3:00</h2>
+      <!-- <h2 class="timer">3:00</h2> -->
     </div>
     <div id="baron" class="power-play hide">
       <img class="baron-pp" src="img/baron.png" alt="baron" />
       <h1 class="pp-text">Baron</h1>
       <div class="pp-bar"></div>
-      <h2 class="timer">3:00</h2>
+      <!-- <h2 class="timer">3:00</h2> -->
     </div>
 
     <div id="platings" class="hide">

--- a/frontend/gfx/ingame.js
+++ b/frontend/gfx/ingame.js
@@ -203,16 +203,16 @@ function setGameState(e) {
 function ppUpdate(e) {
   const typeDiv = e.type === 'Baron' ? baron : elder
   const div = typeDiv.querySelector('.pp-bar')
-  const timer = typeDiv.querySelector('.timer')
+  // const timer = typeDiv.querySelector('.timer')
 
   if (!e.ongoing) {
     div.style.setProperty('--percent', 100)
-    timer.innerText = convertSecsToTime(0)
+    // timer.innerText = convertSecsToTime(0)
 
     typeDiv.classList.add('hide')
   } else {
     div.style.setProperty('--percent', e.percent)
-    timer.innerText = convertSecsToTime(e.respawnIn)
+    // timer.innerText = convertSecsToTime(e.respawnIn)
 
     if (typeDiv.classList.contains('hide')) {
       setTimeout(() => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -293,4 +293,18 @@
   </button>
 </div>
 
+<h3>Test Powerplay</h3>
+<div class="d-flex align-items-center mb-3" style="gap: 1rem">
+  <select class="form-control" id="pp-test" style="width: 24%">
+    <option selected>Baron</option>
+    <option>Dragon</option>
+  </select>
+  <button class="btn btn-primary btn-lg" onclick="testPPTimer(true)">
+    Show Timer
+  </button>
+  <button class="btn btn-danger btn-lg" onclick="testPPTimer(false)">
+    Hide Timer
+  </button>
+</div>
+
 <script src="/pages/op-module-league-in-game/frontend.js" defer></script>


### PR DESCRIPTION
Allows changing the icons of the power play with css such as:
```
.baron-pp {
  content:url(/pages/op-module-league-in-game/gfx/img/baron-icon.png);
}

.elder-pp {
  content:url(/pages/op-module-league-in-game/gfx/img/dragon-icon.png);
}
```

Also changed the text of the "Baron" or "Elder" to text to use the primary font and text color. 

They will then look like
![image](https://user-images.githubusercontent.com/10212682/210106130-5d5aa493-4ec6-4f05-9698-33acfff9b8c6.png)
![image](https://user-images.githubusercontent.com/10212682/210106145-c242d1f5-f9de-4a0a-b16b-1c91b4fdcfa2.png)

Also adds tests to show/hide these PPs.

![image](https://user-images.githubusercontent.com/10212682/210106208-aa8bdbff-9de6-4f03-a5b0-8870faffe2c7.png)

---

Just wondering, why have the times been removed? Is it because they are inaccurate? Just quickly reading the code they seemed to count down to the respawn of the objective, not until the buff expires.