### PR TITLE
Improve Event Customization

### DIFF
--- a/frontend/gfx/ingame.css
+++ b/frontend/gfx/ingame.css
@@ -405,6 +405,24 @@ body {
   transform: translateX(0);
 }
 
+.event.herald .event-img {
+  top: 26.65% !important;
+}
+.event.chemtech .event-img {
+  top: 30% !important;
+}
+.event.infernal .event-img {
+  top: 30% !important;
+}
+.event.mountain .event-img {
+  top: 26.5% !important;
+}
+.event.ocean .event-img {
+  top: 0% !important;
+}
+.event.baron .event-img {
+  top: 28% !important;
+}
 
 .team {
   position: relative;

--- a/frontend/gfx/ingame.css
+++ b/frontend/gfx/ingame.css
@@ -405,24 +405,6 @@ body {
   transform: translateX(0);
 }
 
-.event.herald .event-img {
-  top: 26.65% !important;
-}
-.event.chemtech .event-img {
-  top: 30% !important;
-}
-.event.infernal .event-img {
-  top: 30% !important;
-}
-.event.mountain .event-img {
-  top: 26.5% !important;
-}
-.event.ocean .event-img {
-  top: 0% !important;
-}
-.event.baron .event-img {
-  top: 28% !important;
-}
 
 .team {
   position: relative;

--- a/frontend/gfx/ingame.html
+++ b/frontend/gfx/ingame.html
@@ -110,7 +110,9 @@
         </div>
       </div>
       <div class="event">
-        <h1 class="event-name">Herold</h1>
+        <h1 class="event-name">
+          <span>Herold</span>
+        </h1>
         <h2 class="event-time">AT 15:25</h2>
         <img src="img/mountain.png" class="event-img" />
       </div>
@@ -152,7 +154,9 @@
         </div>
       </div>
       <div class="event">
-        <h1 class="event-name">Herold</h1>
+        <h1 class="event-name">
+          <span>Herold</span>
+        </h1>
         <h2 class="event-time">AT 15:25</h2>
         <img src="img/mountain.png" class="event-img" />
       </div>

--- a/frontend/gfx/ingame.js
+++ b/frontend/gfx/ingame.js
@@ -347,7 +347,8 @@ function emitEvent(e) {
       ? blueTeam.querySelector('.event')
       : redTeam.querySelector('.event')
 
-  eventDiv.querySelector('.event-name').innerText = e.name
+  const eventName = eventDiv.querySelector('.event-name')
+  eventName.querySelector('span').innerText = e.name
   /* eventDiv.querySelector('.event-time').innerText = `AT ${convertSecsToTime(
     e.time
   )}` */


### PR DESCRIPTION
By adding the span object, you can now change the event-name contents through CSS like:
```
.cloud .event-name span {
  display: none;
}
.cloud .event-name:after {
  content: 'Wind Dragon Slain';
}
```

Just allows more customization without having to change code.