### PR TITLE
Change location URL so it accounts for protocol

### DIFF
--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -221,7 +221,7 @@ let server = ''
 
 LPTE.onready(async () => {
   server = await window.constants.getWebServerPort()
-  const location = `${window.location.protocol}://${server}/pages/op-module-league-in-game/gfx`
+  const location = `${window.location.protocol}//${server}/pages/op-module-league-in-game/gfx`
 
   const apiKey = await window.constants.getApiKey()
 

--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -221,7 +221,7 @@ let server = ''
 
 LPTE.onready(async () => {
   server = await window.constants.getWebServerPort()
-  const location = `http://${server}/pages/op-module-league-in-game/gfx`
+  const location = `${window.location.protocol}://${server}/pages/op-module-league-in-game/gfx`
 
   const apiKey = await window.constants.getApiKey()
 


### PR DESCRIPTION
If the tool is running on a reverse proxy with HTTPS, the iframe preview will not work, because the frontend is using https, while requesting an http iframe. 

This change accounts for that.

![image](https://github.com/rcv-prod-toolkit/module-league-in-game/assets/23201434/42c84d82-dc7f-4ac7-bdd8-d2601bfdfc0c)
