### PR TITLE
[Feature] Add team logos next to the tags

### DIFF
--- a/frontend/gfx/ingame.css
+++ b/frontend/gfx/ingame.css
@@ -768,6 +768,19 @@ body {
   margin-left: 25px;
 }
 
+.sb-logo {
+  width: 50px;
+  aspect-ratio: 1;
+  visibility: hidden;
+}
+
+.sb-blue .sb-logo {
+  margin-right: 25px;
+}
+.sb-red .sb-logo {
+  margin-left: 25px;
+}
+
 .sb-score {
   position: absolute;
   top: 0;

--- a/frontend/gfx/ingame.html
+++ b/frontend/gfx/ingame.html
@@ -43,6 +43,7 @@
       <div class="sb-team sb-blue">
         <div class="sb-team-info">
           <div class="sb-score sb-score-blue"></div>
+          <img src="/pages/op-module-teams/img/" alt="" class="sb-logo">
           <h3 class="sb-tag">Tag</h3>
           <h4 class="sb-standing">0-0</h4>
         </div>
@@ -75,6 +76,7 @@
       <div class="sb-team sb-red">
         <div class="sb-team-info">
           <div class="sb-score sb-score-red"></div>
+          <img src="/pages/op-module-teams/img/" alt="" class="sb-logo">
           <h3 class="sb-tag">Tag</h3>
           <h4 class="sb-standing">0-0</h4>
         </div>

--- a/frontend/gfx/ingame.js
+++ b/frontend/gfx/ingame.js
@@ -140,8 +140,10 @@ const sbBluePP = document.querySelector('.sb-blue.power-play')
 const sbRedPP = document.querySelector('.sb-red.power-play')
 
 const sbBlueTag = sbBlue.querySelector('.sb-tag')
+const sbBlueLogo = sbBlue.querySelector('.sb-logo')
 const sbBlueStanding = sbBlue.querySelector('.sb-standing')
 const sbRedTag = sbRed.querySelector('.sb-tag')
+const sbRedLogo = sbRed.querySelector('.sb-logo')
 const sbRedStanding = sbRed.querySelector('.sb-standing')
 
 const sbBlueKills = scoreboard.querySelector('.sb-kills-blue')
@@ -427,8 +429,18 @@ const sbRedScore = scoreboard.querySelector('.sb-score-red')
 function changeColors(e) {
   sbBlueTag.innerText = e.teams.blueTeam?.tag || 'Tag'
   sbRedTag.innerText = e.teams.redTeam?.tag || 'Tag'
+  sbBlueLogo.style.visibility = `hidden`
+  sbRedLogo.style.visibility = `hidden`
   sbBlueStanding.innerText = e.teams.blueTeam?.standing || ''
   sbRedStanding.innerText = e.teams.redTeam?.standing || ''
+  if(e.teams.blueTeam?.logo) {
+    sbBlueLogo.src = `/pages/op-module-teams/img/${e.teams.blueTeam.logo}`
+    sbBlueLogo.style.visibility = 'visible'
+  }
+  if(e.teams.redTeam?.logo) {
+    sbRedLogo.src = `/pages/op-module-teams/img/${e.teams.redTeam.logo}`
+    sbRedLogo.style.visibility = 'visible'
+  }
 
   sbBlueScore.innerHTML = ''
   sbRedScore.innerHTML = ''


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
There were no logos next to the team tags.

**Describe the solution you'd like**
Adding a space to hold a logo from `module-teams`.

**Describe alternatives you've considered**
Manually changing source code.

**Additional context**
Here is an example how it looks (maybe not the best because of theme colors) - left team has no logo
![image](https://github.com/rcv-prod-toolkit/module-league-in-game/assets/46965900/34d6362b-0e2f-4a7c-9809-a0d7adcce2e1)