### PR TITLE
[Feature] Tournament information

### DIFF
--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -20,6 +20,7 @@ document.querySelector('#settings').addEventListener('submit', (e) => {
     ppTimer: document.querySelector('#ppTimer').checked,
     delay: parseInt(document.querySelector('#delay').value),
     showNicknames: document.querySelector('#showNicknames').checked,
+    showTournament: document.querySelector('#showTournament').checked,
     scoreboard: {
       active: document.querySelector('#scoreboard-active').checked,
       score: document.querySelector('#scoreboard-score').checked,
@@ -201,6 +202,7 @@ function initSettings(settings) {
   document.querySelector('#ppTimer').checked = settings.ppTimer
   document.querySelector('#delay').value = settings.delay
   document.querySelector('#showNicknames').checked = settings.showNicknames
+  document.querySelector('#showTournament').checked = settings.showTournament
 
   document.querySelector('#scoreboard-active').checked =
     settings.scoreboard.active

--- a/frontend/gfx/ingame.css
+++ b/frontend/gfx/ingame.css
@@ -310,6 +310,32 @@ body {
   opacity: 0 !important;
 }
 
+#tournament {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: .5rem;
+  position: absolute;
+  bottom: 235px;
+  left: 605px;
+  right: 590px;
+  height: 65px;
+  padding: 5px;
+  background: var(--background-color);
+  border-radius: 20px 20px 0 0;
+  box-shadow: 0 0 0 1px #3f3321, 0 0 0 3px #524b2d, 0 0 0 4px #716441;
+}
+
+#tournament .content {
+  background: -webkit-linear-gradient(#978867, #464030);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+#tournament .phase {
+  text-transform: uppercase;
+}
+
 .event {
   position: absolute;
   left: -2px;

--- a/frontend/gfx/ingame.css
+++ b/frontend/gfx/ingame.css
@@ -330,6 +330,7 @@ body {
   background: -webkit-linear-gradient(#978867, #464030);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+  white-space: nowrap;
 }
 
 #tournament .phase {

--- a/frontend/gfx/ingame.css
+++ b/frontend/gfx/ingame.css
@@ -768,6 +768,19 @@ body {
   margin-left: 25px;
 }
 
+.sb-logo {
+  width: 50px;
+  aspect-ratio: 1;
+  visibility: hidden;
+}
+
+.sb-blue .sb-logo {
+  margin-right: 25px;
+}
+.sb-red .sb-logo {
+  margin-left: 25px;
+}
+
 .sb-score {
   position: absolute;
   top: 0;

--- a/frontend/gfx/ingame.html
+++ b/frontend/gfx/ingame.html
@@ -239,6 +239,12 @@
 
     <div id="killfeed"></div>
 
+    <div id="tournament">
+      <div class="content">
+        <span class="phase"></span> - <span class="name"></span>
+      </div>
+    </div>
+
     <div id="inhibDiv" class="hide">
       <div id="blueSide" class="inhibitors hide">
         <h3>Inhibitors</h3>

--- a/frontend/gfx/ingame.html
+++ b/frontend/gfx/ingame.html
@@ -43,6 +43,7 @@
       <div class="sb-team sb-blue">
         <div class="sb-team-info">
           <div class="sb-score sb-score-blue"></div>
+          <img src="/pages/op-module-teams/img/" alt="" class="sb-logo">
           <h3 class="sb-tag">Tag</h3>
           <h4 class="sb-standing">0-0</h4>
         </div>
@@ -75,6 +76,7 @@
       <div class="sb-team sb-red">
         <div class="sb-team-info">
           <div class="sb-score sb-score-red"></div>
+          <img src="/pages/op-module-teams/img/" alt="" class="sb-logo">
           <h3 class="sb-tag">Tag</h3>
           <h4 class="sb-standing">0-0</h4>
         </div>

--- a/frontend/gfx/ingame.js
+++ b/frontend/gfx/ingame.js
@@ -639,7 +639,7 @@ function updateSettings(e) {
   }
   if (e.showTournament !== showTournament) {
     showTournament = e.showTournament
-    document.querySelector('#tournament').style.display = e.showTournament ? 'block' : 'none'
+    document.querySelector('#tournament').style.display = e.showTournament ? 'flex' : 'none'
   }
 
   if (showScoreBoard !== e.scoreboard.active) {

--- a/frontend/gfx/ingame.js
+++ b/frontend/gfx/ingame.js
@@ -1,6 +1,7 @@
 const blueTeam = document.querySelector('#blue')
 const redTeam = document.querySelector('#red')
 let showNicknames,
+  showTournament,
   showLeaderBoard,
   showScoreBoard,
   score,
@@ -635,6 +636,10 @@ function updateSettings(e) {
         n.style.display = 'block'
       })
     }
+  }
+  if (e.showTournament !== showTournament) {
+    showTournament = e.showTournament
+    document.querySelector('#tournament').style.display = e.showTournament ? 'block' : 'none'
   }
 
   if (showScoreBoard !== e.scoreboard.active) {

--- a/frontend/gfx/ingame.js
+++ b/frontend/gfx/ingame.js
@@ -425,6 +425,16 @@ function changeColor(color) {
 
 const sbBlueScore = scoreboard.querySelector('.sb-score-blue')
 const sbRedScore = scoreboard.querySelector('.sb-score-red')
+const tournamentDiv = document.querySelector('#tournament')
+const roundOfSpan = tournamentDiv.querySelector('.phase')
+const nameSpan = tournamentDiv.querySelector('.name')
+const roundOfMap = {
+  0: 'Upper Bracket Final',
+  1: 'Upper Bracket Final',
+  2: 'Finals',
+  4: 'Semi Finals',
+  8: 'Quarter Finals'
+}
 
 function changeColors(e) {
   sbBlueTag.innerText = e.teams.blueTeam?.tag || 'Tag'
@@ -441,6 +451,9 @@ function changeColors(e) {
     sbRedLogo.src = `/pages/op-module-teams/img/${e.teams.redTeam.logo}`
     sbRedLogo.style.visibility = 'visible'
   }
+  roundOfSpan.textContent = e.roundOf <= 8 ? roundOfMap[e.roundOf] : `Round of ${e.roundOf}`
+  nameSpan.textContent = e.tournamentName
+  resizeText(tournamentDiv)
 
   sbBlueScore.innerHTML = ''
   sbRedScore.innerHTML = ''
@@ -777,6 +790,22 @@ function createLeaderBoardItem(player, max, type = 'xp') {
   lbItem.appendChild(lbMeter)
 
   return lbItem
+}
+
+const isOverflown = ({ clientHeight, scrollHeight, clientWidth, scrollWidth }) => (scrollHeight > clientHeight || scrollWidth > clientWidth)
+
+const resizeText = (parent) => {
+  let i = 20
+  let overflow = false
+  const maxSize = 50
+
+  while (!overflow && i < maxSize) {
+    parent.style.fontSize = `${i}px`
+    overflow = isOverflown(parent)
+    if (!overflow) i++
+  }
+
+  parent.style.fontSize = `${i - 1}px`
 }
 
 LPTE.onready(async () => {

--- a/frontend/gfx/ingame.js
+++ b/frontend/gfx/ingame.js
@@ -800,7 +800,7 @@ function createLeaderBoardItem(player, max, type = 'xp') {
 const isOverflown = ({ clientHeight, scrollHeight, clientWidth, scrollWidth }) => (scrollHeight > clientHeight || scrollWidth > clientWidth)
 
 const resizeText = (parent) => {
-  let i = 20
+  let i = 10
   let overflow = false
   const maxSize = 50
 

--- a/frontend/gfx/ingame.js
+++ b/frontend/gfx/ingame.js
@@ -140,8 +140,10 @@ const sbBluePP = document.querySelector('.sb-blue.power-play')
 const sbRedPP = document.querySelector('.sb-red.power-play')
 
 const sbBlueTag = sbBlue.querySelector('.sb-tag')
+const sbBlueLogo = sbBlue.querySelector('.sb-logo')
 const sbBlueStanding = sbBlue.querySelector('.sb-standing')
 const sbRedTag = sbRed.querySelector('.sb-tag')
+const sbRedLogo = sbRed.querySelector('.sb-logo')
 const sbRedStanding = sbRed.querySelector('.sb-standing')
 
 const sbBlueKills = scoreboard.querySelector('.sb-kills-blue')
@@ -427,8 +429,18 @@ const sbRedScore = scoreboard.querySelector('.sb-score-red')
 function changeColors(e) {
   sbBlueTag.innerText = e.teams.blueTeam?.tag || 'Tag'
   sbRedTag.innerText = e.teams.redTeam?.tag || 'Tag'
+  sbBlueLogo.style.visibility = `hidden`
+  sbRedLogo.style.visibility = `hidden`
   sbBlueStanding.innerText = e.teams.blueTeam?.standing || ''
   sbRedStanding.innerText = e.teams.redTeam?.standing || ''
+  if(e.teams.blueTeam?.logo) {
+    sbBlueLogo.src = `/pages/op-module-teams/img/${e.teams.blueTeam.logo}`
+    sbBlueLogo.style.visibility = 'visible'
+  }
+  if(e.teams.redTeam?.logo) {
+    sbRedLogo.src = `/pages/op-module-teams/img/${e.teams.redTeam.logo}`
+    sbRedLogo.style.visibility = 'visible'
+  }
 
   sbBlueScore.innerHTML = ''
   sbRedScore.innerHTML = ''

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -367,6 +367,15 @@
     />
     <label class="form-check-label" for="showNicknames"> Show Nicknames </label>
   </div>
+  <div class="form-check mb-3">
+    <input
+      class="form-check-input"
+      type="checkbox"
+      value=""
+      id="showTournament"
+    />
+    <label class="form-check-label" for="showTournament"> Show Tournnament Info </label>
+  </div>
   <div class="form-group">
     <button type="submit" class="btn btn-primary">Save Settings</button>
   </div>

--- a/plugin.ts
+++ b/plugin.ts
@@ -25,6 +25,7 @@ module.exports = async (ctx: PluginContext) => {
       killfeed: false,
       ppTimer: false,
       showNicknames: false,
+      showTournament: true,
       delay: 0,
       scoreboard: {
         active: true,
@@ -47,6 +48,7 @@ module.exports = async (ctx: PluginContext) => {
     config.ppTimer = e.ppTimer
     config.delay = e.delay
     config.showNicknames = e.showNicknames
+    config.showTournament = e.showTournament
     config.scoreboard = e.scoreboard
 
     ctx.LPTE.emit({

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -6,6 +6,7 @@ export interface Config {
   ppTimer: boolean
   delay: number
   showNicknames: boolean
+  showTournament: boolean
   scoreboard: {
     active: boolean
     score: boolean


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
There was no option to display tournament phase and name.

**Describe the solution you'd like**
Showing information about current game like this:
![image](https://github.com/rcv-prod-toolkit/module-league-in-game/assets/46965900/9501209c-ac1c-42b8-89d5-e5633290ffc3)

**Describe alternatives you've considered**
Don't know any.

**Additional context**
`Added team logos` commit is from another PR (https://github.com/rcv-prod-toolkit/module-league-in-game/pull/16)
Examples:
![image](https://github.com/rcv-prod-toolkit/module-league-in-game/assets/46965900/5c1ee7d5-1a99-40d7-a81b-ba7b590cd4b0)
By shortened I meant little
![image](https://github.com/rcv-prod-toolkit/module-league-in-game/assets/46965900/590ee65e-e03b-49be-9f40-75413f3d3c3b)
![image](https://github.com/rcv-prod-toolkit/module-league-in-game/assets/46965900/c7345c49-57d4-4611-94e8-1420062c6a4e)
![image](https://github.com/rcv-prod-toolkit/module-league-in-game/assets/46965900/20ead41d-83db-42c4-a379-26242ff2bb91)