### PR TITLE
Change the new liveclientdata_event syntax

### DIFF
--- a/controller/InGameState.ts
+++ b/controller/InGameState.ts
@@ -34,32 +34,39 @@ export class InGameState {
       targetFrameCover: false,
       towers: {
         100: {
-          L: {},
-          C: {},
-          R: {}
+          L2: {},
+          L1: {},
+          L0: {}
         },
         200: {
-          L: {},
-          C: {},
-          R: {}
+          L2: {},
+          L1: {},
+          L0: {}
         }
       },
       platings: {
         showPlatings: false,
         100: {
-          L: 0,
-          C: 0,
-          R: 0
+          L2: 0,
+          L1: 0,
+          L0: 0
         },
         200: {
-          L: 0,
-          C: 0,
-          R: 0
+          L2: 0,
+          L1: 0,
+          L0: 0
         }
       },
       showInhibitors: null,
       inhibitors: {
         100: {
+          L2: {
+            alive: true,
+            respawnAt: 0,
+            respawnIn: 0,
+            percent: 0,
+            time: 0
+          },
           L1: {
             alive: true,
             respawnAt: 0,
@@ -67,14 +74,7 @@ export class InGameState {
             percent: 0,
             time: 0
           },
-          C1: {
-            alive: true,
-            respawnAt: 0,
-            respawnIn: 0,
-            percent: 0,
-            time: 0
-          },
-          R1: {
+          L0: {
             alive: true,
             respawnAt: 0,
             respawnIn: 0,
@@ -83,6 +83,13 @@ export class InGameState {
           }
         },
         200: {
+          L2: {
+            alive: true,
+            respawnAt: 0,
+            respawnIn: 0,
+            percent: 0,
+            time: 0
+          },
           L1: {
             alive: true,
             respawnAt: 0,
@@ -90,14 +97,7 @@ export class InGameState {
             percent: 0,
             time: 0
           },
-          C1: {
-            alive: true,
-            respawnAt: 0,
-            respawnIn: 0,
-            percent: 0,
-            time: 0
-          },
-          R1: {
+          L0: {
             alive: true,
             respawnAt: 0,
             respawnIn: 0,
@@ -372,7 +372,7 @@ export class InGameState {
 
       if (event.eventname === EventType.TurretPlateDestroyed) {
         const split = event.other.split('_') as string[]
-        const lane = split[2] as 'L' | 'C' | 'R'
+        const lane = split[2] as 'L2' | 'L1' | 'L0'
         this.gameState.platings[team][lane] += 1
 
         this.ctx.LPTE.emit({
@@ -876,8 +876,8 @@ export class InGameState {
 
   private handleInhibEvent(event: Event, allGameData: AllGameData) {
     const split = event.InhibKilled.split('_') as string[]
-    const team = split[1] === 'T1' ? 100 : 200
-    const lane = split[2] as 'L1' | 'C1' | 'R1'
+    const team = split[1] === 'T100' ? 100 : 200
+    const lane = split[2] as 'L2' | 'L1' | 'L0'
     const respawnAt = Math.round(event.EventTime) + 60 * 5
     const time = event.EventTime
 
@@ -967,8 +967,8 @@ export class InGameState {
     if (event.TurretKilled === 'Obelisk') return
 
     const split = event.TurretKilled.split('_') as string[]
-    const team = split[1] === 'T1' ? 100 : 200
-    const lane = split[2] as 'L' | 'C' | 'R'
+    const team = split[1] === 'T100' ? 100 : 200
+    const lane = split[2] as 'L2' | 'L1' | 'L0'
     const turret = split[3]
 
     if (this.config.killfeed) {

--- a/types/InGameEvent.ts
+++ b/types/InGameEvent.ts
@@ -38,9 +38,14 @@ export enum MobType {
 }
 
 export enum StructureType {
+  /* Deprecated
   Turret_T2_R_03_A = 'Turret_T2_R_03_A',
   Turret_T2_C_03_A = 'Turret_T2_C_03_A',
   Turret_T2_L_03_A = 'Turret_T2_L_03_A'
+  */
+    Turret_T200_L0_P3_ID = 'Turret_T200_L0_P3_ID',
+    Turret_T200_L1_P3_ID = 'Turret_T200_L1_P3_ID',
+    Turret_T200_L2_P3_ID = 'Turret_T200_L2_P3_ID',
 }
 
 export enum TeamType {

--- a/types/InGameState.ts
+++ b/types/InGameState.ts
@@ -60,24 +60,31 @@ export interface Objective {
 }
 
 export interface TowerState {
-  L: {
+  L2: {
     [turret: string]: boolean
   }
-  C: {
+  L1: {
     [turret: string]: boolean
   }
-  R: {
+  L0: {
     [turret: string]: boolean
   }
 }
 
 export interface PlatingState {
-  L: number
-  C: number
-  R: number
+  L2: number
+  L1: number
+  L0: number
 }
 
 export interface InhibitorState {
+  L2: {
+    alive: boolean
+    respawnIn: number
+    respawnAt: number
+    percent: number
+    time: number
+  }
   L1: {
     alive: boolean
     respawnIn: number
@@ -85,14 +92,7 @@ export interface InhibitorState {
     percent: number
     time: number
   }
-  C1: {
-    alive: boolean
-    respawnIn: number
-    respawnAt: number
-    percent: number
-    time: number
-  }
-  R1: {
+  L0: {
     alive: boolean
     respawnIn: number
     respawnAt: number


### PR DESCRIPTION
 from R | C | L -> L2, L1, L0, which caused the server to crash on the "TurretKilled"-Event

Here is a very detailed picture of the new system.
![NewLiveEventAPILOL](https://github.com/user-attachments/assets/41c7ff87-47b7-48f5-b267-bd1bf52efc10)

I debugged your server with the posts of the live api tool from riot:
https://127.0.0.1:2999/liveclientdata/allgamedata

The server didn't crash since this commit...